### PR TITLE
Fix docs of `@btime` and `@btimed` in ChairmarksExtras.jl

### DIFF
--- a/src/ChairmarksExtras.jl
+++ b/src/ChairmarksExtras.jl
@@ -12,7 +12,7 @@ Benchmark `f` and return the fasted runtime in seconds.
 
 Equivalent to `(@b args...).time`.
 
-See `@be` for more info.
+See also [`@be`](@ref).
 """
 macro belapsed(args...)
     :(@b($(args...)).time)
@@ -25,7 +25,7 @@ integer if the allocation pattern of `f` is nondeterministic.
 
 Similar to `(@b args...).bytes`.
 
-See `@be` for more info.
+See also [`@be`](@ref).
 """
 macro ballocated(args...)
     :(@b($(args...)).bytes)
@@ -38,7 +38,7 @@ integer if the allocation pattern of `f` is nondeterministic.
 
 Similar to `(@b args...).allocs`.
 
-See `@be` for more info.
+See also [`@be`](@ref).
 """
 macro ballocations(args...)
     :(@b($(args...)).allocs)
@@ -71,9 +71,9 @@ end
 Benchmark `f` and return a `NamedTuple` containing both the performance information and the
 result of end of the pipeline.
 
-Similar to `Base.@timed`
+Similar to `Base.@timed`.
 
-See `@be` for more info on arguments and execution model
+See also [`@be`](@ref).
 
 # Examples
 ```julia-repl
@@ -104,11 +104,11 @@ end
     @btime [[init] setup] f [teardown] keywords...
 
 Benchmark `f`; print the runtime, amount of allocations, and other relevant performance
-information; and return the result of end of the pipeline
+information; and return the result of end of the pipeline.
 
-Similar to `Base.@time`
+Similar to `Base.@time`.
 
-See `@be` for more info on arguments and execution model
+See also [`@be`](@ref).
 
 # Examples
 ```julia-repl

--- a/src/ChairmarksExtras.jl
+++ b/src/ChairmarksExtras.jl
@@ -65,7 +65,41 @@ function save_result(expr)
 
     end
 end
+"""
+    @btimed [[init] setup] f [teardown] keywords...
 
+Benchmark `f` and return a `NamedTuple` containing both the performance information and the
+result of end of the pipeline.
+
+Similar to `Base.@timed`
+
+See `@be` for more info on arguments and execution model
+
+# Examples
+```julia-repl
+julia> @btimed 1+1
+(value = 2, time = 1.1338457460906442e-9, bytes = 0.0, gctime = 0.0, allocations = 0.0, compile_time = 0.0, recompile_time = 0.0)
+
+julia> @btimed @eval begin f(x) = x+5; f(7) end
+(value = 12, time = 0.001291175, bytes = 39584.0, gctime = 0.0, allocations = 859.0, compile_time = 0.0009262507034496286, recompile_time = 0.0)
+
+julia> @btimed rand(4) sort seconds=1
+(value = [0.2657034395624964, 0.2816572316379955, 0.5107416699597612, 0.908363448987202], time = 1.7637310606060608e-8, bytes = 96.0, gctime = 0.0, allocations = 2.0, compile_time = 0.0, recompile_time = 0.0)
+"""
+macro btimed(args...)
+    quote
+        perf,value = $(save_result(Chairmarks.process_args(args)))
+        (
+            value=value,
+            time=perf.time,
+            bytes=perf.bytes,
+            gctime=perf.gc_fraction*perf.time,
+            allocations=perf.allocs,
+            compile_time=perf.compile_fraction*perf.time,
+            recompile_time=perf.time*perf.compile_fraction*perf.recompile_fraction,
+        )
+    end
+end
 """
     @btime [[init] setup] f [teardown] keywords...
 
@@ -93,41 +127,6 @@ julia> @btime rand(4) sort seconds=1
  0.28547170596819316
  0.6337243664545191
  0.9911675357522034
-"""
-macro btimed(args...)
-    quote
-        perf,value = $(save_result(Chairmarks.process_args(args)))
-        (
-            value=value,
-            time=perf.time,
-            bytes=perf.bytes,
-            gctime=perf.gc_fraction*perf.time,
-            allocations=perf.allocs,
-            compile_time=perf.compile_fraction*perf.time,
-            recompile_time=perf.time*perf.compile_fraction*perf.recompile_fraction,
-        )
-    end
-end
-"""
-    @btimed [[init] setup] f [teardown] keywords...
-
-Benchmark `f` and return a `NamedTuple` containing both the performance information and the
-result of end of the pipeline.
-
-Similar to `Base.@timed`
-
-See `@be` for more info on arguments and execution model
-
-# Examples
-```julia-repl
-julia> @btimed 1+1
-(value = 2, time = 1.1338457460906442e-9, bytes = 0.0, gctime = 0.0, allocations = 0.0, compile_time = 0.0, recompile_time = 0.0)
-
-julia> @btimed @eval begin f(x) = x+5; f(7) end
-(value = 12, time = 0.001291175, bytes = 39584.0, gctime = 0.0, allocations = 859.0, compile_time = 0.0009262507034496286, recompile_time = 0.0)
-
-julia> @btimed rand(4) sort seconds=1
-(value = [0.2657034395624964, 0.2816572316379955, 0.5107416699597612, 0.908363448987202], time = 1.7637310606060608e-8, bytes = 96.0, gctime = 0.0, allocations = 2.0, compile_time = 0.0, recompile_time = 0.0)
 """
 macro btime(args...)
     quote


### PR DESCRIPTION
The original docs are reversed.