### PR TITLE
Swap btime and btimed docstrings and add trailing backticks

### DIFF
--- a/src/ChairmarksExtras.jl
+++ b/src/ChairmarksExtras.jl
@@ -66,6 +66,45 @@ function save_result(expr)
 end
 
 """
+    @btimed [[init] setup] f [teardown] keywords...
+
+Benchmark `f` and return a `NamedTuple` containing both the performance information and the
+result of end of the pipeline.
+
+Similar to `Base.@timed`
+
+See `@be` for more info on arguments and execution model
+
+# Examples
+```julia-repl
+julia> @btimed 1+1
+(value = 2, time = 1.1338457460906442e-9, bytes = 0.0, gctime = 0.0, allocations = 0.0, compile_time = 0.0, recompile_time = 0.0)
+
+julia> @btimed @eval begin f(x) = x+5; f(7) end
+(value = 12, time = 0.001291175, bytes = 39584.0, gctime = 0.0, allocations = 859.0, compile_time = 0.0009262507034496286, recompile_time = 0.0)
+
+julia> @btimed rand(4) sort seconds=1
+(value = [0.2657034395624964, 0.2816572316379955, 0.5107416699597612, 0.908363448987202], time = 1.7637310606060608e-8, bytes = 96.0, gctime = 0.0, allocations = 2.0, compile_time = 0.0, recompile_time = 0.0)
+```
+"""
+macro btimed(args...)
+    quote
+        full,value = $(save_result(Chairmarks.process_args(args)))
+        summarized = Chairmarks.summarize(full)
+        (
+            value=value,
+            time=summarized.time,
+            bytes=summarized.bytes,
+            gctime=summarized.gc_fraction*summarized.time,
+            allocations=summarized.allocs,
+            compile_time=summarized.compile_fraction*summarized.time,
+            recompile_time=summarized.time*summarized.compile_fraction*summarized.recompile_fraction,
+            evals=summarized.evals,
+            samples=length(full.samples),
+        )
+    end
+end
+"""
     @btime [[init] setup] f [teardown] keywords...
 
 Benchmark `f`; print the runtime, amount of allocations, and other relevant performance
@@ -92,44 +131,7 @@ julia> @btime rand(4) sort seconds=1
  0.28547170596819316
  0.6337243664545191
  0.9911675357522034
-"""
-macro btimed(args...)
-    quote
-        full,value = $(save_result(Chairmarks.process_args(args)))
-        summarized = Chairmarks.summarize(full)
-        (
-            value=value,
-            time=summarized.time,
-            bytes=summarized.bytes,
-            gctime=summarized.gc_fraction*summarized.time,
-            allocations=summarized.allocs,
-            compile_time=summarized.compile_fraction*summarized.time,
-            recompile_time=summarized.time*summarized.compile_fraction*summarized.recompile_fraction,
-            evals=summarized.evals,
-            samples=length(full.samples),
-        )
-    end
-end
-"""
-    @btimed [[init] setup] f [teardown] keywords...
-
-Benchmark `f` and return a `NamedTuple` containing both the performance information and the
-result of end of the pipeline.
-
-Similar to `Base.@timed`
-
-See `@be` for more info on arguments and execution model
-
-# Examples
-```julia-repl
-julia> @btimed 1+1
-(value = 2, time = 1.1338457460906442e-9, bytes = 0.0, gctime = 0.0, allocations = 0.0, compile_time = 0.0, recompile_time = 0.0)
-
-julia> @btimed @eval begin f(x) = x+5; f(7) end
-(value = 12, time = 0.001291175, bytes = 39584.0, gctime = 0.0, allocations = 859.0, compile_time = 0.0009262507034496286, recompile_time = 0.0)
-
-julia> @btimed rand(4) sort seconds=1
-(value = [0.2657034395624964, 0.2816572316379955, 0.5107416699597612, 0.908363448987202], time = 1.7637310606060608e-8, bytes = 96.0, gctime = 0.0, allocations = 2.0, compile_time = 0.0, recompile_time = 0.0)
+```
 """
 macro btime(args...)
     quote


### PR DESCRIPTION
#4 by @singularitti, but without the unrelated formatting changes.